### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "nuget"
-    directory: "/src"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
-
-  - package-ecosystem: "nuget"
-    directory: "/tests"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"
-      
+- package-ecosystem: nuget
+  directory: "/"
+  schedule:
+    interval: daily


### PR DESCRIPTION
Dependabot seems to have so many issues that going back to the simplest form of configuration is better than nothing.