### PR TITLE
Increase open pull requests limit to 50

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,4 @@ updates:
     all-dependencies:
       patterns:
         - "*"
+  open-pull-requests-limit: 50


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to allow up to 50 simultaneous automated dependency update pull requests, increasing throughput of maintenance updates and shortening turnaround for security and version bumps.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->